### PR TITLE
Adding sanitization against emtpy inter-space extractions

### DIFF
--- a/src/data_acquisition.cpp
+++ b/src/data_acquisition.cpp
@@ -1026,9 +1026,9 @@ void Acquisition::getMemLoad() {
   double buffers   = 0;
 
   for (unsigned long i = 1; i < results.size(); i++) {
-    if (results[i].empty()){
-        continue;
-        }
+    if (results[i].empty()) {
+      continue;
+    }
 
     if (isdigit(results[i].front())) {
       try {
@@ -1044,9 +1044,9 @@ void Acquisition::getMemLoad() {
   boost::split(results, line3, [](char c) { return c == ' '; });
 
   for (unsigned long i = 1; i < results.size(); i++) {
-    if (results[i].empty()){
-        continue;
-        }
+    if (results[i].empty()) {
+      continue;
+    }
 
     if (isdigit(results[i].front())) {
       try {
@@ -1062,9 +1062,9 @@ void Acquisition::getMemLoad() {
   boost::split(results, line4, [](char c) { return c == ' '; });
 
   for (size_t i = 1; i < results.size(); i++) {
-    if (results[i].empty()){
-        continue;
-        }
+    if (results[i].empty()) {
+      continue;
+    }
 
     if (isdigit(results[i].front())) {
 

--- a/src/data_acquisition.cpp
+++ b/src/data_acquisition.cpp
@@ -1026,6 +1026,9 @@ void Acquisition::getMemLoad() {
   double buffers   = 0;
 
   for (unsigned long i = 1; i < results.size(); i++) {
+    if (results[i].empty()){
+        continue;
+        }
 
     if (isdigit(results[i].front())) {
       try {
@@ -1041,6 +1044,9 @@ void Acquisition::getMemLoad() {
   boost::split(results, line3, [](char c) { return c == ' '; });
 
   for (unsigned long i = 1; i < results.size(); i++) {
+    if (results[i].empty()){
+        continue;
+        }
 
     if (isdigit(results[i].front())) {
       try {
@@ -1056,6 +1062,9 @@ void Acquisition::getMemLoad() {
   boost::split(results, line4, [](char c) { return c == ' '; });
 
   for (size_t i = 1; i < results.size(); i++) {
+    if (results[i].empty()){
+        continue;
+        }
 
     if (isdigit(results[i].front())) {
 


### PR DESCRIPTION
In Ubuntu 26.04 the output of the `/proc/meminfo` command has the values and labels separated by multiple spaces.
This makes `boost:split` generate multiple elements of empty strings before getting to the values.
Consequently, this makes status crash upon addressing the contents of such elements ( `if (isdigit(results[i].front())) {...`).
This PR adds sanitation to skip empty split elements.